### PR TITLE
Invalid room handling

### DIFF
--- a/client/src/main/java/Client.java
+++ b/client/src/main/java/Client.java
@@ -58,24 +58,39 @@ public class Client extends Application {
                 NetworkManager.getInstance().requestNewRoom(
                         lobbyController.getName(),
                         true,
-                        responseRoomInfo -> {
-                            System.out.println("Connected (creating): " + responseRoomInfo.toString());
-                            connectToGame(primaryStage, lobbyController.getName(), responseRoomInfo);
+                        responseRoom -> {
+                            System.out.println("Connected (creating): " + responseRoom.toString());
+                            connectToGame(primaryStage, lobbyController.getName(), responseRoom);
                         },
-                        null
+                        responseRoom -> {
+                            System.out.println("Got rejected");
+                        }
                 );
             });
 
             lobbyController.setJoinHandler(room -> {
                 System.out.println("Selected room: " + room.toString());
+
+                waitingController.applyScene(primaryStage);
+
+                // TODO Remove the sleep. This is a test to see what happens if the room vanishes before we can join
+                try {
+                    Thread.sleep(10000);
+                }
+                catch(InterruptedException ex) {
+
+                }
+
                 NetworkManager.getInstance().requestJoinRoom(
                         lobbyController.getName(),
                         room,
-                        responseRoomInfo -> {
-                            System.out.println("Connected (joining): " + responseRoomInfo.toString());
-                            connectToGame(primaryStage, lobbyController.getName(), responseRoomInfo);
+                        responseRoom -> {
+                            System.out.println("Connected (joining): " + responseRoom.toString());
+                            connectToGame(primaryStage, lobbyController.getName(), responseRoom);
                         },
-                        null
+                        responseRoom -> {
+                            System.out.println("Got rejected");
+                        }
                 );
             });
 

--- a/client/src/main/java/Client.java
+++ b/client/src/main/java/Client.java
@@ -2,6 +2,8 @@ import Messages.RoomInfo;
 import Network.NetworkManager;
 import UI.*;
 import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.control.Alert;
 import javafx.stage.Stage;
 
 
@@ -70,16 +72,7 @@ public class Client extends Application {
 
             lobbyController.setJoinHandler(room -> {
                 System.out.println("Selected room: " + room.toString());
-
                 waitingController.applyScene(primaryStage);
-
-                // TODO Remove the sleep. This is a test to see what happens if the room vanishes before we can join
-                try {
-                    Thread.sleep(10000);
-                }
-                catch(InterruptedException ex) {
-
-                }
 
                 NetworkManager.getInstance().requestJoinRoom(
                         lobbyController.getName(),
@@ -89,7 +82,17 @@ public class Client extends Application {
                             connectToGame(primaryStage, lobbyController.getName(), responseRoom);
                         },
                         responseRoom -> {
-                            System.out.println("Got rejected");
+                            NetworkManager.getInstance().stopWaitingForRoom();
+
+                            Platform.runLater(() -> {
+                                Alert alert = new Alert(Alert.AlertType.ERROR);
+                                alert.setTitle("Error");
+                                alert.setHeaderText("Failed to join the room");
+                                alert.setContentText("The room either no longer exists or is now full.");
+                                alert.showAndWait();
+
+                                lobbyController.applyScene(primaryStage);
+                            });
                         }
                 );
             });

--- a/client/src/main/java/Network/HeartbeatThreadCallback.java
+++ b/client/src/main/java/Network/HeartbeatThreadCallback.java
@@ -40,7 +40,7 @@ public class HeartbeatThreadCallback implements Runnable {
             try {
                 Messages.Heartbeat beat = new Heartbeat();
                 pn.publish().message(beat).channel(getOutgoingChannel()).sync();
-                System.out.println("Thump");
+                //System.out.println("Thump");
             } catch (PubNubException ex) {
                 System.out.println("SKIPPED A BEAT: " + ex.toString());
             }

--- a/client/src/main/java/Network/NetworkManager.java
+++ b/client/src/main/java/Network/NetworkManager.java
@@ -13,7 +13,6 @@ import com.pubnub.api.models.consumer.PNStatus;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -228,8 +227,8 @@ public final class NetworkManager {
             };
         }
 
-        callback.setSuccessResponse(successResponse);
-        callback.setFailureResponse(failureResponse);
+        callback.setSuccessCallback(successResponse);
+        callback.setFailureCallback(failureResponse);
 
 
         changeListener(callback, Arrays.asList(incomingChannel));
@@ -270,8 +269,8 @@ public final class NetworkManager {
             };
         }
 
-        callback.setSuccessResponse(successResponse);
-        callback.setFailureResponse(failureResponse);
+        callback.setSuccessCallback(successResponse);
+        callback.setFailureCallback(failureResponse);
 
         changeListener(callback, Arrays.asList(incomingChannel));
     }

--- a/client/src/main/java/Network/RoomRequesterCallback.java
+++ b/client/src/main/java/Network/RoomRequesterCallback.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 /**
  * Attempts to ask for a room from the engine. This can be used either
- * for joining or for creating a room. (If the roomInfo object has an ID,
+ * for joining or for creating a room. (If the request object has an ID,
  * it's assumed we're joining. Otherwise, it's assumed we're creating.)
  */
 public class RoomRequesterCallback extends SubscribeCallback {
@@ -23,35 +23,35 @@ public class RoomRequesterCallback extends SubscribeCallback {
     private String ourUserID;
     private String outgoingChannel;
     private String incomingChannel;
-    private RoomInfo roomInfo;
-    private Consumer<RoomInfo> successResponse;
-    private Consumer<RoomInfo> failureResponse;
+    private RoomInfo request;
+    private Consumer<RoomInfo> successCallback;
+    private Consumer<RoomInfo> failureCallback;
 
     public RoomRequesterCallback(String ourUserID, String outgoingChannel, String incomingChannel, RoomInfo roomInfo) {
         this.ourUserID = ourUserID;
         this.outgoingChannel = outgoingChannel;
         this.incomingChannel = incomingChannel;
 
-        this.roomInfo = roomInfo;
+        this.request = roomInfo;
     }
 
     /**
      * Sets the callback to use when we've successfully gotten a room which we
      * may join.
-     * @param successResponse Response to use. May be null, and overrides old callbacks.
+     * @param successCallback Response to use. May be null, and overrides old callbacks.
      */
-    public void setSuccessResponse(Consumer<RoomInfo> successResponse) {
-        this.successResponse = successResponse;
+    public void setSuccessCallback(Consumer<RoomInfo> successCallback) {
+        this.successCallback = successCallback;
     }
 
     /**
      * Sets the callback to use when we've failed to get a room which we
      * may join. This can occur for several reasons, and might be able
      * to be deduced based on the RoomInfo object.
-     * @param failureResponse Response to use. May be null, and overrides old callbacks.
+     * @param failureCallback Response to use. May be null, and overrides old callbacks.
      */
-    public void setFailureResponse(Consumer<RoomInfo> failureResponse) {
-        this.failureResponse = failureResponse;
+    public void setFailureCallback(Consumer<RoomInfo> failureCallback) {
+        this.failureCallback = failureCallback;
     }
 
     /**
@@ -60,8 +60,8 @@ public class RoomRequesterCallback extends SubscribeCallback {
      * @param pubnub Used for sending the message.
      */
     public void cancelRequest(PubNub pubnub) {
-        roomInfo.setRequestMode(RoomInfo.RequestType.DISCONNECT);
-        pubnub.publish().channel(outgoingChannel).message(roomInfo).async(new PNCallback<PNPublishResult>() {
+        request.setRequestMode(RoomInfo.RequestType.DISCONNECT);
+        pubnub.publish().channel(outgoingChannel).message(request).async(new PNCallback<PNPublishResult>() {
             @Override
             public void onResponse(PNPublishResult result, PNStatus status) { }
         });
@@ -81,7 +81,7 @@ public class RoomRequesterCallback extends SubscribeCallback {
             // Or just use the connected event to confirm you are subscribed for
             // UI / internal notifications, etc
 
-            pubnub.publish().channel(outgoingChannel).message(roomInfo).async(new PNCallback<PNPublishResult>() {
+            pubnub.publish().channel(outgoingChannel).message(request).async(new PNCallback<PNPublishResult>() {
                 @Override
                 public void onResponse(PNPublishResult result, PNStatus status) {
                     // Check whether request successfully completed or not.
@@ -117,13 +117,15 @@ public class RoomRequesterCallback extends SubscribeCallback {
         if(sourceChannel.equals(incomingChannel)) {
             //JsonObject json = message.getMessage().getAsJsonObject();
             //String creator = json.get("Creator").getAsString();
-            RoomInfo responseRoomInfo = Converter.fromJson(message.getMessage(), RoomInfo.class);
+            RoomInfo response = Converter.fromJson(message.getMessage(), RoomInfo.class);
 
-            System.out.println(responseRoomInfo.toString());
+            System.out.println(response.toString());
 
-            // TODO Check for success/failure
-            if(successResponse != null) {
-                successResponse.accept(responseRoomInfo);
+            if (response.getRequestMode().equals(RoomInfo.RequestType.DENIED) && failureCallback != null) {
+                failureCallback.accept(response);
+            }
+            else if(successCallback != null) {
+                successCallback.accept(response);
             }
 
         }

--- a/library/src/main/java/Messages/RoomInfo.java
+++ b/library/src/main/java/Messages/RoomInfo.java
@@ -12,7 +12,7 @@ public class RoomInfo {
      * Marks which kind of request this is, assuming it's getting sent across PubNub.
      */
     public static enum RequestType {
-        RESULT, CREATE, JOIN, DISCONNECT
+        NORMAL, DISCONNECT, DENIED
     }
 
     public static final int defaultRoomID = -1;
@@ -27,13 +27,25 @@ public class RoomInfo {
     private String player1Token = "X";
     private String player2Token = "O";
 
-    private RequestType requestMode = RequestType.RESULT;
+    private RequestType requestMode = RequestType.NORMAL;
 
-
+    /**
+     * Creates a room object which tells the engine that we are no longer
+     * interested in joining.
+     * @param player The player who is not interested in joining.
+     * @return An object which represents a disconnect request.
+     */
     public static RoomInfo makeDisconnectRoom(PlayerInfo player) {
         RoomInfo result = new RoomInfo();
         result.setPlayer1(player);
         result.setRequestMode(RequestType.DISCONNECT);
+
+        return result;
+    }
+
+    public static RoomInfo makeDeniedRoom() {
+        RoomInfo result = new RoomInfo();
+        result.setRequestMode(RequestType.DENIED);
 
         return result;
     }


### PR DESCRIPTION
This adds in code for both the client and the engine to handle an invalid join request. The client will complain if it gets rejected.

This also fixes a rather major bug tied to room removals. (Rooms were getting deleted when the game began, as opposed to just unlisted.)